### PR TITLE
[Fix] #52 DB 개인정보 이슈 레코드수 표시방식 변경

### DIFF
--- a/src/main/java/com/lastcommit/piilot/domain/dbscan/dto/response/DbPiiIssueResponseDTO.java
+++ b/src/main/java/com/lastcommit/piilot/domain/dbscan/dto/response/DbPiiIssueResponseDTO.java
@@ -28,7 +28,7 @@ public record DbPiiIssueResponseDTO(
                 column.getName(),
                 column.getPiiType().getType().getDisplayName(),
                 column.getPiiType().getType().name(),
-                total - enc,
+                Math.max(0, total - enc),
                 total,
                 column.getRiskLevel(),
                 issue.getUserStatus(),


### PR DESCRIPTION
## 개요
<!---- 자신이 완료한 이슈를 닫아주세요 -->
- closed #52
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
- DB 개인정보 이슈 목록의 레코드 표시 데이터 확장
- 변경 사항: 프론트엔드 UI 변경(보안필요/총 레코드 형식)에 대응하기 위해, 기존 총 레코드 수만 반환하던 API 응답에 '보안필요(미암호화) 레코드 수' 필드를 추가하고 산출 로직을 반영

<!---- Resolves: #(Issue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

📣 **To Reviewers**
---
- 핵심 로직: 별도의 DB 스키마 변경 없이, 기존 엔티티의 총 레코드와 암호화 레코드 필드를 활용해 DTO 생성 시 연산(total - enc)되도록 구현
- API 명세: 필드 추가에 따른 Swagger 문서를 갱신했으니 프론트엔드 작업 시 참고

<!-- 전달사항 -->

- Reviewers : 팀 선택
- Labels : 작업 유형, 자기 자신

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 새로운 기능
* API 응답에 암호화되지 않은 레코드 수(unencRecordsCount)가 추가되었습니다.
* 총 레코드 수 및 암호화된 레코드 수를 바탕으로 암호화되지 않은 수를 계산해 응답 정확성이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->